### PR TITLE
Add option to send headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ var serve = function(options) {
     }
 
     var docRoot = metalsmith.destination();
-    var fileServer = new web.Server(docRoot, { cache: options.cache, indexFile: options.indexFile });
+    var fileServer = new web.Server(docRoot, { cache: options.cache, indexFile: options.indexFile, headers: options.headers });
 
     server = require('http').createServer(function (request, response) {
       request.addListener('end', function () {
@@ -80,7 +80,8 @@ var defaults = {
   host: "localhost",
   verbose: false,
   listDirectories: false,
-  indexFile: "index.html"
+  indexFile: "index.html",
+  headers: {}
 };
 
 var plugin = function (options) {


### PR DESCRIPTION
This option will be passed directly to node-static and can be used to set headers like i.e. Content-Encoding