### PR TITLE
Not setting option object causes serve to fail

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,10 @@ var defaults = {
 };
 
 var plugin = function (options) {
+  if (!options) {
+    return
+  }
+  
   Object.keys(defaults).forEach(function(key) {
     if (!options[key]) {
       options[key] = defaults[key];

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,9 +97,7 @@ var defaults = {
 };
 
 var plugin = function (options) {
-  if (!options) {
-    return
-  }
+  options = options || {}
   
   Object.keys(defaults).forEach(function(key) {
     if (!options[key]) {


### PR DESCRIPTION
Using:

```js
var serve = require('metalsmith-serve')

metalsmith(__dirnam)
  .use(serve())
```

Fails with:

```
/Users/dana/code/blog/node_modules/metalsmith-serve/lib/index.js:101
    if (!options[key]) {
                ^

TypeError: Cannot read property 'cache' of undefined
    at /Users/dana/code/blog/node_modules/metalsmith-serve/lib/index.js:101:17
    at Array.forEach (native)
    at plugin (/Users/dana/code/blog/node_modules/metalsmith-serve/lib/index.js:100:25)
    at Object.<anonymous> (/Users/dana/code/blog/bin/build:74:10)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
    at startup (node.js:117:18)
    at node.js:951:3
```

If I change it to use `serve({})` the code works correctly. 

The provided patch checks to make sure that option are set and if not set options to an empty object.