### PR TITLE
Added support for defining the document root

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Default: `0`
 
 Number of seconds to cache served files
 
+### document_root
+Type: `String`
+Default: `metalsmith.destination()`
+
+Directory which to serve. Given path will be resolved with `path.resolve()`
+
 ### verbose
 Type: `Boolean`
 Default: `false`

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var serve = function(options) {
       return;
     }
 
-    var docRoot = metalsmith.destination();
+    var docRoot = options.document_root ? path.resolve(options.document_root) : metalsmith.destination();
     var fileServer = new web.Server(docRoot, { cache: options.cache, indexFile: options.indexFile, headers: options.headers });
 
     server = require('http').createServer(function (request, response) {

--- a/test/index.js
+++ b/test/index.js
@@ -183,6 +183,69 @@ describe('metalsmith-serve with custom indexFile', function(){
 
 });
 
+describe('metalsmith-serve with custom document_root', function(){
+
+  var metalsmith;
+  var servePlugin;
+  var docRoot;
+
+  before(function(done) {
+    metalsmith = Metalsmith("test/fixtures/site");
+    docRoot = 'test/fixtures/customindex/src';
+
+    servePlugin = serve({
+      document_root: docRoot,
+      verbose: false,
+      "port": port,
+      indexFile: "index.txt"
+    });
+
+    metalsmith
+      .use(servePlugin)
+      .build(function(err) {
+        if (err) throw err;
+        done();
+      });
+  });
+
+  after(function(done) {
+    servePlugin.shutdown(done);
+  });
+
+  it('should serve custom document root', function(done){
+
+    var callback = function(res) {
+      var body = '';
+
+      res.on('data', function(buf) {
+        body += buf;
+      });
+
+      res.on('end', function() {
+        assert.equal(res.statusCode, 200);
+        var contents = fs.readFileSync(path.join(docRoot, 'index.txt'), "utf8");
+        assert.equal(body, contents);
+      });
+
+      res.on('error', function(e) {
+        throw(e);
+      });
+
+      done();
+    };
+
+    var options = {
+      host: "localhost",
+      "port": port,
+      path: "/"
+    };
+
+    var req = http.request(options, callback)
+    req.end();
+
+  });
+});
+
 
 // not_found file serving and redirects
 describe('metalsmith-serve custom http errors and redirects', function() {


### PR DESCRIPTION
My use case: I need to publish files to a subdirectory (say, `build/sub`) and I'm using [prefixoid](https://www.npmjs.com/package/metalsmith-prefixoid) to adjust links. However, to make everything work correctly, metalsmith-serve should serve files from `build` and not `build/sub`, but this cannot be done because of fixed root directory.

Therefore an option is needed.