### PR TITLE
Check to make sure options is an object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,10 @@ var defaults = {
 };
 
 var plugin = function (options) {
+  if (typeof options !== 'object') {
+    options = defaults
+  }
+
   Object.keys(defaults).forEach(function(key) {
     if (!options[key]) {
       options[key] = defaults[key];


### PR DESCRIPTION
Not passing `options` to metalsmith-serve throws an exception, eg:

```js
metalsmith.use(serve())
```

Results in:

```
/Users/dana/code/blog/node_modules/metalsmith-serve/lib/index.js:102
    if (!options[key]) {
                ^

TypeError: Cannot read property 'cache' of undefined
    at /Users/dana/code/blog/node_modules/metalsmith-serve/lib/index.js:102:17
    at Array.forEach (native)
    at plugin (/Users/dana/code/blog/node_modules/metalsmith-serve/lib/index.js:101:25)
    at Object.<anonymous> (/Users/dana/code/blog/bin/build:87:10)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
    at startup (node.js:117:18)
    at node.js:951:3
```

If I instead pass in a blank object things work:

```js
metalsmith.use(serve({}))
```

This PR makes sure that `options` is set, and if it isn't, set them to `defaults`.