### PR TITLE
Adding an option to enable node-static's gzip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ e.g.
 }
 ```
 
+### gzip
+Type: `Boolean`
+Default: `false`
+
+Enable `node-static`'s gzip option. [Read more here](https://github.com/cloudhead/node-static#gzip).
+
 ## License
 
   MIT

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var defaults = {
   verbose: false,
   listDirectories: false,
   indexFile: "index.html",
+  gzip: false,
   headers: {},
   redirects: {}
 };
@@ -28,7 +29,7 @@ var serve = function(options) {
     }
 
     var docRoot = options.document_root ? path.resolve(options.document_root) : metalsmith.destination();
-    var fileServer = new web.Server(docRoot, { cache: options.cache, indexFile: options.indexFile, headers: options.headers });
+    var fileServer = new web.Server(docRoot, { cache: options.cache, indexFile: options.indexFile, headers: options.headers, gzip: options.gzip });
 
     server = require('http').createServer(function (request, response) {
       request.addListener('end', function () {


### PR DESCRIPTION
This PR adds a `gzip` option so users can access the `gzip` option on `node-static`. See: https://github.com/cloudhead/node-static#gzip